### PR TITLE
chores(config): Current xstream-run is causing client exception. Bump…

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@cycle/dom": "10.0.0-rc28",
     "@cycle/isolate": "^1.3.2",
-    "@cycle/xstream-run": "^2.0.0",
+    "@cycle/xstream-run": "^3.0.0",
     "cyclic-router": "^2.0.0",
     "es6-shim": "^0.35.1",
     "normalize-css": "^2.3.1",


### PR DESCRIPTION
client generates exception: runSA.remember() is not a function.

Issue has been opened in cyclic-router repository. Only exist in xstream-run@2.0.0. Bumping version to 3.0.0 fixes the problem.
