### PR TITLE
Fix nightwatch pointing to wrong jar file

### DIFF
--- a/nightwatch.js
+++ b/nightwatch.js
@@ -8,7 +8,7 @@ module.exports = {
 
   'selenium': {
     'start_process': true,
-    'server_path': 'node_modules/selenium-server/lib/runner/selenium-server-standalone-2.53.0.jar',
+    'server_path': 'node_modules/selenium-server/lib/runner/selenium-server-standalone-2.53.1.jar',
     'log_path': '',
     'host': '127.0.0.1',
     'port': 4444,


### PR DESCRIPTION
Currently `server_path` is hardcoded and fails because the path is wrong.

Might want to think about how to automate this in the future so we don't have to specify it everytime but I'm not familiar with `nightwatch`

I hope you can help with inputs on this issue @TylorS 
