### PR TITLE
chore(package.json): add BUILD_ENV to npm run build

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "npm run lint && npm run unit-test && npm run e2e-test",
     "serve-static": "pushstate-server dist/ 8080 /200.html",
     "serve": "cross-env BABEL_ENV=development babel-node ./node_modules/webpack-dev-server/bin/webpack-dev-server",
-    "build": "cross-env BABEL_ENV=production babel-node ./node_modules/webpack/bin/webpack"
+    "build": "cross-env BABEL_ENV=production BUILD_ENV=production babel-node ./node_modules/webpack/bin/webpack"
   },
   "config": {
     "commitizen": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ const imagePath = path.resolve('./dist/images')
 const basePlugins =
   [
     new webpack.EnvironmentPlugin([ 'BUILD_ENV' ]),
-    new webpack.NoErrorsPlugin(),    
+    new webpack.NoErrorsPlugin(),
     new ExtractTextPlugin('styles.css', { allChunks: true })
   ]
 
@@ -22,11 +22,11 @@ const browserSync = [
     reload: false
   })
 ]
-  
+
 const devPlugins = [
   new webpack.HotModuleReplacementPlugin(),
   ...browserSync
-]  
+]
 
 const prodPlugins =
   [
@@ -82,16 +82,24 @@ const environmentOptions =
     devtool: 'eval'
   }
 
+const devEntry = [
+  'webpack-dev-server/client?http://localhost:8080',
+  'webpack/hot/only-dev-server',
+]
+
+const defaultEntry = [path.join(srcPath, 'app.js')]
+
+const entry =
+  process.env.BUILD_ENV === 'production'
+  ? defaultEntry
+  : devEntry.concat(defaultEntry)
+
 module.exports = {
   plugins,
 
   ...environmentOptions,
 
-  entry: [
-    'webpack-dev-server/client?http://localhost:8080',
-    'webpack/hot/only-dev-server',
-    path.join(srcPath, 'app.js')
-  ],
+  entry,
 
   output: {
     path: path.resolve('./dist'),


### PR DESCRIPTION
**Description:**
Currently, `npm run build` is not built with BUILD_ENV set to production. Build is not uglified.

This PR adds `BUILD_ENV=production` in the `package.json`
